### PR TITLE
Make it possible for hub admins to enable Diaspora by default

### DIFF
--- a/diaspora/diaspora.php
+++ b/diaspora/diaspora.php
@@ -3317,6 +3317,8 @@ function diaspora_feature_settings_post(&$a,&$b) {
 
 function diaspora_feature_settings(&$a,&$s) {
 	$dspr_allowed = get_pconfig(local_channel(),'system','diaspora_allowed');
+	if($dspr_allowed === false)
+		$dspr_allowed = get_config('diaspora','allowed');	
 	$pubcomments = get_pconfig(local_channel(),'system','diaspora_public_comments');
 	if($pubcomments === false)
 		$pubcomments = 1;


### PR DESCRIPTION
If not set or  'util/config diaspora allowed 0' disables Diaspora for all channels, except where explicitly enabled by channel (current behaviour). 'util/config diaspora allowed 1' enables Diaspora for all channels, except where explicitly disabled. 

Closes bug #1.