### PR TITLE
add url redirection /&JS=1 to metatag

### DIFF
--- a/metatag/metatag.php
+++ b/metatag/metatag.php
@@ -54,6 +54,13 @@ case "/";
     $a->page['htmlhead'] .= "$keywords" . "\r\n";
 break;
 
+case "/&JS=1";
+    $a->page['htmlhead'] .= "$hreflang" . "\r\n";
+    $a->page['htmlhead'] .= "$robots" . "\r\n";
+    $a->page['htmlhead'] .= "$description" . "\r\n";
+    $a->page['htmlhead'] .= "$keywords" . "\r\n";
+break;
+
 case "/register";
     $a->page['htmlhead'] .= "$hreflang" . "\r\n";
     $a->page['htmlhead'] .= "$robots" . "\r\n";


### PR DESCRIPTION
Some Search engines like Google and Yahoo detect redirect the URL to /&JS=1 and metatags not show correctly add in configuration for Url Simple "/" and "/&JS=1"