### PR TITLE
Add salmon link information to the public feed when GNU-Social is ena…

### DIFF
--- a/cdav/cdav.php
+++ b/cdav/cdav.php
@@ -9,7 +9,7 @@
  * 
  */
 
-require_once('addon/cdav/Mod_Cdav.php');
+//require_once('addon/cdav/Mod_Cdav.php');
 require_once('addon/cdav/include/widgets.php');
 
 function cdav_install() {
@@ -166,7 +166,7 @@ function cdav_feature_settings_post(&$b) {
  	if($_POST['cdav-submit']) {
 
 		$channel = \App::get_channel();
-		$uri = 'principals/' . $channel['channel_address'];
+		$uri = 'principals/' . $channel['channel_hash'];
 
 		set_pconfig(local_channel(),'cdav','enabled',intval($_POST['cdav_enabled']));
 		if(intval($_POST['cdav_enabled'])) {
@@ -192,7 +192,7 @@ function cdav_feature_settings_post(&$b) {
 					dbesc('VEVENT,VTODO')
 				);
 
-				$r = q("insert into calendarinstances (calendarid, principaluri, displayname, uri, description, calendarcolor) values(LAST_INSERT_ID(), '%s', '%s', '%s', '%s', '%s') ",
+				$r = q("insert into calendarinstances (principaluri, displayname, uri, description, calendarcolor) values( '%s', '%s', '%s', '%s', '%s') ",
 					dbesc($uri),
 					dbesc(t('Default Calendar')),
 					dbesc('default'),

--- a/cdav/cdav.php
+++ b/cdav/cdav.php
@@ -9,7 +9,7 @@
  * 
  */
 
-//require_once('addon/cdav/Mod_Cdav.php');
+require_once('addon/cdav/Mod_Cdav.php');
 require_once('addon/cdav/include/widgets.php');
 
 function cdav_install() {
@@ -166,7 +166,7 @@ function cdav_feature_settings_post(&$b) {
  	if($_POST['cdav-submit']) {
 
 		$channel = \App::get_channel();
-		$uri = 'principals/' . $channel['channel_hash'];
+		$uri = 'principals/' . $channel['channel_address'];
 
 		set_pconfig(local_channel(),'cdav','enabled',intval($_POST['cdav_enabled']));
 		if(intval($_POST['cdav_enabled'])) {
@@ -192,7 +192,7 @@ function cdav_feature_settings_post(&$b) {
 					dbesc('VEVENT,VTODO')
 				);
 
-				$r = q("insert into calendarinstances (principaluri, displayname, uri, description, calendarcolor) values( '%s', '%s', '%s', '%s', '%s') ",
+				$r = q("insert into calendarinstances (calendarid, principaluri, displayname, uri, description, calendarcolor) values(LAST_INSERT_ID(), '%s', '%s', '%s', '%s', '%s') ",
 					dbesc($uri),
 					dbesc(t('Default Calendar')),
 					dbesc('default'),

--- a/gnusoc/gnusoc.php
+++ b/gnusoc/gnusoc.php
@@ -33,7 +33,7 @@ function gnusoc_load() {
 	register_hook('follow_from_feed','addon/gnusoc/gnusoc.php','gnusoc_follow_from_feed');
 	register_hook('atom_entry','addon/gnusoc/gnusoc.php','gnusoc_atom_entry');
 	register_hook('parse_atom','addon/gnusoc/gnusoc.php','gnusoc_parse_atom');
-
+	register_hook('atom_feed','addon/gnusoc/gnusoc.php','gnusoc_atom_feed');
 
 
 //	register_hook('notifier_hub', 'addon/gnusoc/gnusoc.php', 'gnusoc_process_outbound');
@@ -55,6 +55,7 @@ function gnusoc_unload() {
 	unregister_hook('follow_from_feed','addon/gnusoc/gnusoc.php','gnusoc_follow_from_feed');
 	unregister_hook('atom_entry','addon/gnusoc/gnusoc.php','gnusoc_atom_entry');
 	unregister_hook('parse_atom','addon/gnusoc/gnusoc.php','gnusoc_parse_atom');
+	unregister_hook('atom_feed','addon/gnusoc/gnusoc.php','gnusoc_atom_feed');
 
 }
 
@@ -605,6 +606,17 @@ function gnusoc_atom_entry($a,&$b) {
 	$o .= '<ostatus:conversation>' . xmlify($conv) . '</ostatus:conversation>' . "\r\n";
 
 	$b['entry'] = str_replace('</entry>', $o . '</entry>', $b['entry']);
+
+}
+
+function gnusoc_atom_feed($a,&$b) {
+	$x = preg_match('|' . z_root() . '/channel/(.*?) |',$b,$matches);
+	if($x) {
+		$b = str_replace('</generator>','</generator>' . "\r\n  " . 
+		'<rel="salmon" href="' . z_root() . '/salmon/' . $matches[1] . ' />' . "\r\n  " . 
+		'<rel="http://salmon-protocol.org/ns/salmon-replies" href="' . z_root() . '/salmon/' . $matches[1] . ' />' . "\r\n  " .
+		'<rel="http://salmon-protocol.org/ns/salmon-mention" href="' . z_root() . '/salmon/' . $matches[1] . ' />',$b);
+	}
 
 }
 

--- a/gnusoc/gnusoc.php
+++ b/gnusoc/gnusoc.php
@@ -612,6 +612,10 @@ function gnusoc_atom_entry($a,&$b) {
 function gnusoc_atom_feed($a,&$b) {
     $x = preg_match('|' . 'href\=(.*?)' . z_root() . '/channel/(.*?) |',$b,$matches);
 
+	$y = preg_match('|' . z_root() . '/photo/profile/l/(.*?)"|',$b,$matches2);
+
+logger('matches2: ' . print_r($matches2,true));
+
     if($x) {
         $b = str_replace('</generator>','</generator>' . "\r\n  " .
         '<link rel="salmon" href="' . z_root() . '/salmon/' . $matches[2] . ' />' . "\r\n  " .
@@ -619,6 +623,11 @@ function gnusoc_atom_feed($a,&$b) {
 		"\r\n  " .
         '<link rel="http://salmon-protocol.org/ns/salmon-mention" href="' . z_root() . '/salmon/' . $matches[2] . ' />',$b);
     }
+	if($y) {
+		$b = str_replace('</generator>','</generator>' . "\r\n  " .
+		'<logo>' . z_root() . '/photo/profile/l/' . $matches2[1] . '</logo>',$b);
+	}
+
 }
 
 function gnusoc_parse_atom($a,&$b) {

--- a/gnusoc/gnusoc.php
+++ b/gnusoc/gnusoc.php
@@ -610,14 +610,15 @@ function gnusoc_atom_entry($a,&$b) {
 }
 
 function gnusoc_atom_feed($a,&$b) {
-	$x = preg_match('|' . z_root() . '/channel/(.*?) |',$b,$matches);
-	if($x) {
-		$b = str_replace('</generator>','</generator>' . "\r\n  " . 
-		'<rel="salmon" href="' . z_root() . '/salmon/' . $matches[1] . ' />' . "\r\n  " . 
-		'<rel="http://salmon-protocol.org/ns/salmon-replies" href="' . z_root() . '/salmon/' . $matches[1] . ' />' . "\r\n  " .
-		'<rel="http://salmon-protocol.org/ns/salmon-mention" href="' . z_root() . '/salmon/' . $matches[1] . ' />',$b);
-	}
+    $x = preg_match('|' . 'href\=(.*?)' . z_root() . '/channel/(.*?) |',$b,$matches);
 
+    if($x) {
+        $b = str_replace('</generator>','</generator>' . "\r\n  " .
+        '<link rel="salmon" href="' . z_root() . '/salmon/' . $matches[2] . ' />' . "\r\n  " .
+        '<link rel="http://salmon-protocol.org/ns/salmon-replies" href="' . z_root() . '/salmon/' . $matches[2] . ' />' . 
+		"\r\n  " .
+        '<link rel="http://salmon-protocol.org/ns/salmon-mention" href="' . z_root() . '/salmon/' . $matches[2] . ' />',$b);
+    }
 }
 
 function gnusoc_parse_atom($a,&$b) {

--- a/gnusoc/gnusoc.php
+++ b/gnusoc/gnusoc.php
@@ -612,10 +612,6 @@ function gnusoc_atom_entry($a,&$b) {
 function gnusoc_atom_feed($a,&$b) {
     $x = preg_match('|' . 'href\=(.*?)' . z_root() . '/channel/(.*?) |',$b,$matches);
 
-	$y = preg_match('|' . z_root() . '/photo/profile/l/(.*?)"|',$b,$matches2);
-
-logger('matches2: ' . print_r($matches2,true));
-
     if($x) {
         $b = str_replace('</generator>','</generator>' . "\r\n  " .
         '<link rel="salmon" href="' . z_root() . '/salmon/' . $matches[2] . ' />' . "\r\n  " .
@@ -623,11 +619,6 @@ logger('matches2: ' . print_r($matches2,true));
 		"\r\n  " .
         '<link rel="http://salmon-protocol.org/ns/salmon-mention" href="' . z_root() . '/salmon/' . $matches[2] . ' />',$b);
     }
-	if($y) {
-		$b = str_replace('</generator>','</generator>' . "\r\n  " .
-		'<logo>' . z_root() . '/photo/profile/l/' . $matches2[1] . '</logo>',$b);
-	}
-
 }
 
 function gnusoc_parse_atom($a,&$b) {

--- a/gnusoc/gnusoc.php
+++ b/gnusoc/gnusoc.php
@@ -612,6 +612,8 @@ function gnusoc_atom_entry($a,&$b) {
 function gnusoc_atom_feed($a,&$b) {
     $x = preg_match('|' . 'href\=(.*?)' . z_root() . '/channel/(.*?) |',$b,$matches);
 
+	$y = preg_match('|' . z_root() . '/photo/profile/l/(.*?)"|',$b,$matches2);
+
     if($x) {
         $b = str_replace('</generator>','</generator>' . "\r\n  " .
         '<link rel="salmon" href="' . z_root() . '/salmon/' . $matches[2] . ' />' . "\r\n  " .
@@ -619,6 +621,10 @@ function gnusoc_atom_feed($a,&$b) {
 		"\r\n  " .
         '<link rel="http://salmon-protocol.org/ns/salmon-mention" href="' . z_root() . '/salmon/' . $matches[2] . ' />',$b);
     }
+	if($y) {
+		$b = str_replace('</generator>','</generator>' . "\r\n  " .
+		'<logo>' . z_root() . '/photo/profile/l/' . $matches2[1] . '</logo>',$b);
+	}
 }
 
 function gnusoc_parse_atom($a,&$b) {


### PR DESCRIPTION
…bled. Older GS servers will find it from webfinger. Newer servers also find it from webfinger, but then over-write their discovered link with an empty string when they look for it in the feed if they don't also find it there.