### PR TITLE
Porting of gravatar plugin

### DIFF
--- a/gravatar/README.md
+++ b/gravatar/README.md
@@ -1,0 +1,42 @@
+# Gravatar Plugin
+by [Klaus Weidenbach](http://friendica.dszdw.net/profile/klaus)
+
+This addon allows you to look up an avatar image for new users and contacts at [Gravatar](http://www.gravatar.com). This will be used if there have not been found any other avatar images yet for example through OpenID.
+
+Gravatar is a popular, but centralized and proprietary service where people can store an avatar image for their email-addresses. It is widely used on many pages, for example to display an avatar for comment functions, profile pages, etc.
+
+* * *
+
+# Configuration
+## Default Avatar Image
+If no avatar was found for an email Gravatar can create some pseudo-random generated avatars based on an email hash. You can choose between these presets:
+
+* __Gravatar__: default static Gravatar logo
+* __MM__: (mystery-man) a static image
+* __Identicon__: a generated geometric pattern based on email hash
+* __Monsterid__: a generated 'monster' with different colors, faces, etc. based on email hash
+* __Wavatar__: faces with different features and backgrounds based on email hash
+* __Retro__: 8-bit arcade-styled pixelated faces based on email hash
+
+See examples at [Gravatar][1].
+## Avatar Rating
+Gravatar lets users self-rate their images to be used at appropriate audiences. Choose which are appropriate for your friendica site:
+
+* __g__: suitable for display on all wesites with any audience type
+* __pg__: may contain rude gestures, provocatively dressed individuals, the lesser swear words, or mild violence
+* __r__: may contain such things as harsh profanity, intense violence, nudity, or hard drug use
+* __x__: may contain hardcore sexual imagery or extremely disurbing violence
+
+See more information at [Gravatar][1].
+
+## Alternative Configuration
+Open the .htconfig.php file and add "gravatar" to the list of activated addons:
+
+        $a->config['system']['addon'] = "..., gravatar";
+
+You can add two configuration variables for the addon:
+
+        $a->config['gravatar']['default_avatar'] = "identicon";
+        $a->config['gravatar']['rating'] = "g";
+
+[1]: http://www.gravatar.com/site/implement/images/ "See documentation at Gravatar for more information"

--- a/gravatar/README.md
+++ b/gravatar/README.md
@@ -1,5 +1,6 @@
 # Gravatar Plugin
-by [Klaus Weidenbach](http://friendica.dszdw.net/profile/klaus)
+Autor: [Klaus Weidenbach](http://friendica.dszdw.net/profile/klaus)
+Maintainer: [Sergey Lukin](mailto:sergey.lukin@cybergnosis.su)
 
 This addon allows you to look up an avatar image for new users and contacts at [Gravatar](http://www.gravatar.com). This will be used if there have not been found any other avatar images yet for example through OpenID.
 
@@ -17,6 +18,7 @@ If no avatar was found for an email Gravatar can create some pseudo-random gener
 * __Monsterid__: a generated 'monster' with different colors, faces, etc. based on email hash
 * __Wavatar__: faces with different features and backgrounds based on email hash
 * __Retro__: 8-bit arcade-styled pixelated faces based on email hash
+* __Hub_Default__: default profile photo for your hub
 
 See examples at [Gravatar][1].
 ## Avatar Rating
@@ -28,15 +30,5 @@ Gravatar lets users self-rate their images to be used at appropriate audiences. 
 * __x__: may contain hardcore sexual imagery or extremely disurbing violence
 
 See more information at [Gravatar][1].
-
-## Alternative Configuration
-Open the .htconfig.php file and add "gravatar" to the list of activated addons:
-
-        $a->config['system']['addon'] = "..., gravatar";
-
-You can add two configuration variables for the addon:
-
-        $a->config['gravatar']['default_avatar'] = "identicon";
-        $a->config['gravatar']['rating'] = "g";
 
 [1]: http://www.gravatar.com/site/implement/images/ "See documentation at Gravatar for more information"

--- a/gravatar/README.md
+++ b/gravatar/README.md
@@ -1,6 +1,6 @@
 # Gravatar Plugin
 Autor: [Klaus Weidenbach](http://friendica.dszdw.net/profile/klaus)
-Maintainer: [Sergey Lukin](mailto:sergey.lukin@cybergnosis.su)
+Portig to Hubzilla: [Sergey Lukin](mailto:sergey.lukin@cybergnosis.su)
 
 This addon allows you to look up an avatar image for new users and contacts at [Gravatar](http://www.gravatar.com). This will be used if there have not been found any other avatar images yet for example through OpenID.
 

--- a/gravatar/gravatar.php
+++ b/gravatar/gravatar.php
@@ -5,7 +5,7 @@
  * Version: 1.1
  * MinVersion: 1.14
  * Author: Klaus Weidenbach <http://friendica.dszdw.net/profile/klaus>
- * Maintainer: Sergey Lukin <mailto:sergey.lukin@cybergnosis.su>
+ * Portig to Hubzilla: Sergey Lukin <mailto:sergey.lukin@cybergnosis.su>
  */
 
 /**

--- a/gravatar/gravatar.php
+++ b/gravatar/gravatar.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Name: Gravatar Support
+ * Description: If there is no avatar image for a new user or contact this plugin will look for one at Gravatar.
+ * Version: 1.1
+ * MinVersion: 1.14
+ * Author: Klaus Weidenbach <http://friendica.dszdw.net/profile/klaus>
+ */
+
+/**
+ * Installs the plugin hook
+ */
+function gravatar_load() {
+	register_hook('get_profile_photo', 'addon/gravatar/gravatar.php', 'gravatar_get_profile_photo');
+    logger("registered gravatar in get_profile_photo hook");
+}
+
+/**
+ * Removes the plugin hook
+ */
+function gravatar_unload() {
+    unregister_hook('get_profile_photo', 'addon/gravatar/gravatar.php', 'gravatar_get_profile_photo');
+	logger("unregistered gravatar in get_profile_photo hook");
+}
+
+/**
+ * Looks up the avatar at gravatar.com and returns the URL.
+ *
+ * @param $a array
+ * @param &$b array
+ */
+function gravatar_get_profile_photo($a, &$b) {
+    $r = q("SELECT *
+            FROM photo
+            WHERE imgscale = %d
+            AND uid = %d
+            AND photo_usage = %d
+            LIMIT 1",
+            intval($b['imgscale']),
+            intval($b['channel_id']),
+            intval(PHOTO_PROFILE)
+    );
+    if (count($r)) {
+        $b['data'] = dbunescbin($r[0]['content']);
+        $b['mimetype'] = $r[0]['mimetype'];
+        if(intval($r[0]['os_storage'])) {
+            $b['data'] = file_get_contents($data);
+        }
+        return;
+    }
+    $r = q("SELECT channel_account_id
+            FROM channel
+            WHERE channel_id = %d
+            LIMIT 1",
+            intval($b['channel_id'])
+    );
+    if (!count($r)) {
+        return;
+    }
+    $r = q("SELECT account_email
+            FROM account
+            WHERE account_id = %d
+            LIMIT 1",
+            intval($r[0]['channel_account_id'])
+    );
+    $email = '';
+    if(count($r)) {
+        $email = $r[0]['account_email'];
+    } else {
+        return;
+    }
+    $resolutions = [300, 300, 300, 300, 300, 80, 48];
+    $imgscale = $b['imgscale'];
+    if ($imgscale > 6) {
+        $imgscale = 6;
+    }
+
+	$default_avatar = get_config('gravatar', 'default_img');
+	$rating = get_config('gravatar', 'rating');
+
+	// setting default value if nothing configured
+	if (!$default_avatar) {
+		$default_avatar = 'identicon'; // default image will be a random pattern
+    }
+	if (!$rating) {
+		$rating = 'g'; // suitable for display on all websites with any audience type
+    }
+    $hash = md5(trim(strtolower($email)));
+	$url = 'https://secure.gravatar.com/avatar/' . $hash . '.jpg?s=' . $resolutions[$imgscale] .'&r=' . $rating;
+	if ($default_avatar != "gravatar") {
+		$url .= '&d=' . $default_avatar;
+    }
+    $b['mimetype'] = 'image/jpg';
+	$b['data'] = file_get_contents($url);
+}
+
+/**
+ * Display admin settings for this addon
+ */
+function gravatar_plugin_admin (&$a, &$o) {
+	$t = get_markup_template( "admin.tpl", "addon/gravatar/" );
+	$default_avatar = get_config('gravatar', 'default_img');
+	$rating = get_config('gravatar', 'rating');
+
+	// set default values for first configuration
+    if (!$default_avatar) {
+		$default_avatar = 'identicon'; // pseudo-random geometric pattern based on email hash
+    }
+	if (!$rating) {
+		$rating = 'g'; // suitable for display on all websites with any audience type
+    }
+	// Available options for the select boxes
+	$default_avatars = array(
+		'mm' => t('generic profile image'),
+		'identicon' => t('random geometric pattern'),
+		'monsterid' => t('monster face'),
+		'wavatar' => t('computer generated face'),
+		'retro' => t('retro arcade style face'),
+	);
+	$ratings = array(
+		'g' => 'g',
+		'pg' => 'pg',
+		'r' => 'r',
+		'x' => 'x'
+	);
+
+	// Check if Libravatar is enabled and show warning
+	$r = q("SELECT * FROM addon WHERE aname = '%s' and installed = 1",
+		dbesc('libravatar')
+	);
+	if (count($r)) {
+		$o = '<h5>' .t('Information') .'</h5><p>' .t('Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar.') .'</p><br><br>';
+	}
+
+	// output Gravatar settings
+	$o .= '<input type="hidden" name="form_security_token" value="' .get_form_security_token("gravatarsave") .'">';
+
+	$o .= replace_macros( $t, array(
+		'$submit' => t('Save Settings'),
+		'$default_avatar' => array('avatar', t('Default avatar image'), $default_avatar, t('Select default avatar image if none was found at Gravatar. See README'), $default_avatars),
+		'$rating' => array('rating', t('Rating of images'), $rating, t('Select the appropriate avatar rating for your site. See README'), $ratings)
+	));
+}
+
+/**
+ * Save admin settings
+ */
+function gravatar_plugin_admin_post (&$a) {
+	check_form_security_token('gravatarsave');
+	$default_avatar = ((x($_POST, 'avatar')) ? notags(trim($_POST['avatar'])) : 'identicon');
+	$rating = ((x($_POST, 'rating')) ? notags(trim($_POST['rating'])) : 'g');
+	set_config('gravatar', 'default_img', $default_avatar);
+	set_config('gravatar', 'rating', $rating);
+	info( t('Gravatar settings updated.') .EOL);
+}
+?>

--- a/gravatar/lang/C/messages.po
+++ b/gravatar/lang/C/messages.po
@@ -1,0 +1,73 @@
+# ADDON gravatar
+# Copyright (C) 
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr ""
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr ""
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr ""
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr ""
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr ""
+
+#: gravatar.php:89
+msgid "Information"
+msgstr ""
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr ""
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr ""
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr ""
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr ""
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr ""
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr ""
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr ""

--- a/gravatar/lang/ca/strings.php
+++ b/gravatar/lang/ca/strings.php
@@ -1,0 +1,15 @@
+<?php
+
+$a->strings["generic profile image"] = "imatge de perfil genérica";
+$a->strings["random geometric pattern"] = "Patró geometric aleatori";
+$a->strings["monster face"] = "Cara monstruosa";
+$a->strings["computer generated face"] = "Cara monstruosa generada per ordinador";
+$a->strings["retro arcade style face"] = "Cara d'estil arcade retro";
+$a->strings["Information"] = "informació";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "";
+$a->strings["Submit"] = "Enviar";
+$a->strings["Default avatar image"] = "Imatge d'avatar per defecte";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Se selecciona  la imatge d'avatar per defecte si no es troba cap en Gravatar. Veure el README";
+$a->strings["Rating of images"] = "Classificació de les imatges";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Selecciona la classe d'avatar apropiat pel teu lloc. Veure el README";
+$a->strings["Gravatar settings updated."] = "Ajustos de Gravatar actualitzats.";

--- a/gravatar/lang/cs/messages.po
+++ b/gravatar/lang/cs/messages.po
@@ -1,0 +1,75 @@
+# ADDON gravatar
+# Copyright (C)
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+# 
+# Translators:
+# Michal Šupler <msupler@gmail.com>, 2014-2015
+msgid ""
+msgstr ""
+"Project-Id-Version: friendica\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: 2015-02-11 19:41+0000\n"
+"Last-Translator: Michal Šupler <msupler@gmail.com>\n"
+"Language-Team: Czech (http://www.transifex.com/projects/p/friendica/language/cs/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: cs\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr "generický profilový obrázek"
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr "náhodný geometrický vzor"
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr "tvář příšery"
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr "počítačově generovaná tvář"
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr "tvář v retro arkádovém stylu"
+
+#: gravatar.php:89
+msgid "Information"
+msgstr "Informace"
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr "Libravatar doplněk je také nainstalován. Prosím zakažte doplněk Libravatar nebo tento doplněk Gravatar.<br>Libravatar doplněk se vrátí k doplňku Gravatar, pokud na Libravataru nebude nic nalezeno."
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr "Odeslat"
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr "Defaultní obrázek avataru"
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr "Nastavte defaulní obrázek avatara pokud ho již nemáte na Gravatar. Více viz. soubor README."
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr "Hodnocení obrázků"
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr "Zadejte ohodnocení příslušného avatara pro vaši stránku. Viz README."
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr "Nastavení Gravatar aktualizováno."

--- a/gravatar/lang/cs/strings.php
+++ b/gravatar/lang/cs/strings.php
@@ -1,0 +1,20 @@
+<?php
+
+if(! function_exists("string_plural_select_cs")) {
+function string_plural_select_cs($n){
+	return ($n==1) ? 0 : ($n>=2 && $n<=4) ? 1 : 2;;
+}}
+;
+$a->strings["generic profile image"] = "generický profilový obrázek";
+$a->strings["random geometric pattern"] = "náhodný geometrický vzor";
+$a->strings["monster face"] = "tvář příšery";
+$a->strings["computer generated face"] = "počítačově generovaná tvář";
+$a->strings["retro arcade style face"] = "tvář v retro arkádovém stylu";
+$a->strings["Information"] = "Informace";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "Libravatar doplněk je také nainstalován. Prosím zakažte doplněk Libravatar nebo tento doplněk Gravatar.<br>Libravatar doplněk se vrátí k doplňku Gravatar, pokud na Libravataru nebude nic nalezeno.";
+$a->strings["Submit"] = "Odeslat";
+$a->strings["Default avatar image"] = "Defaultní obrázek avataru";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Nastavte defaulní obrázek avatara pokud ho již nemáte na Gravatar. Více viz. soubor README.";
+$a->strings["Rating of images"] = "Hodnocení obrázků";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Zadejte ohodnocení příslušného avatara pro vaši stránku. Viz README.";
+$a->strings["Gravatar settings updated."] = "Nastavení Gravatar aktualizováno.";

--- a/gravatar/lang/de/messages.po
+++ b/gravatar/lang/de/messages.po
@@ -1,0 +1,76 @@
+# ADDON gravatar
+# Copyright (C)
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+# 
+# Translators:
+# Abrax <webmaster@a-zwenkau.de>, 2014
+# bavatar <tobias.diekershoff@gmx.net>, 2014
+msgid ""
+msgstr ""
+"Project-Id-Version: friendica\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: 2014-10-15 12:29+0000\n"
+"Last-Translator: Abrax <webmaster@a-zwenkau.de>\n"
+"Language-Team: German (http://www.transifex.com/projects/p/friendica/language/de/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr "generisches Profilbild"
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr "zufälliges Profilbild"
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr "Monsterfratze"
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr "computergeneriertes Gesicht"
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr "Retro Arcade Design Gesicht"
+
+#: gravatar.php:89
+msgid "Information"
+msgstr "Information"
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr "Das Libravatar Addon ist ebenfalls installiert. Bitte deaktiviere das Libravatar Addon oder dieses Gravatar Addon.<br>"
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr "Senden"
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr "Standard Profilbild "
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr "Wähle das Standardprofilbild, wenn kein Bild auf Gravatar gefunden wurde. Schaue auch sonst im README nach."
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr "Bildbewertung"
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr "Wähle eine angemessene Bildbewertung für deinen Server. Schaue auch sonst im README nach."
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr "Gravatar Einstellungen aktualisiert."

--- a/gravatar/lang/de/strings.php
+++ b/gravatar/lang/de/strings.php
@@ -1,0 +1,20 @@
+<?php
+
+if(! function_exists("string_plural_select_de")) {
+function string_plural_select_de($n){
+	return ($n != 1);;
+}}
+;
+$a->strings["generic profile image"] = "generisches Profilbild";
+$a->strings["random geometric pattern"] = "zufälliges Profilbild";
+$a->strings["monster face"] = "Monsterfratze";
+$a->strings["computer generated face"] = "computergeneriertes Gesicht";
+$a->strings["retro arcade style face"] = "Retro Arcade Design Gesicht";
+$a->strings["Information"] = "Information";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "Das Libravatar Addon ist ebenfalls installiert. Bitte deaktiviere das Libravatar Addon oder dieses Gravatar Addon.<br>";
+$a->strings["Submit"] = "Senden";
+$a->strings["Default avatar image"] = "Standard Profilbild ";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Wähle das Standardprofilbild, wenn kein Bild auf Gravatar gefunden wurde. Schaue auch sonst im README nach.";
+$a->strings["Rating of images"] = "Bildbewertung";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Wähle eine angemessene Bildbewertung für deinen Server. Schaue auch sonst im README nach.";
+$a->strings["Gravatar settings updated."] = "Gravatar Einstellungen aktualisiert.";

--- a/gravatar/lang/eo/strings.php
+++ b/gravatar/lang/eo/strings.php
@@ -1,0 +1,15 @@
+<?php
+
+$a->strings["generic profile image"] = "komuna profilbildo";
+$a->strings["random geometric pattern"] = "loteca geometria skemo";
+$a->strings["monster face"] = "monstrobildo";
+$a->strings["computer generated face"] = "komputita vizaĝo";
+$a->strings["retro arcade style face"] = "retrostila videoludstila vizaĝo";
+$a->strings["Information"] = "Informo";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "La Libravatar kromprogramo estas ankaŭ instaltga. Bonvolu malŝalti la Libravatar kromprogramon.<br>La Libravatar kromprogramo retropaŝos al Gravatar se neniu troveblis ĉe Libravatar.";
+$a->strings["Submit"] = "Sendi";
+$a->strings["Default avatar image"] = "Defaŭlta avatarbildo";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Elektu defaŭltan avatarbildon se neniu troviĝis ĉe Gravatar. Vidu README.";
+$a->strings["Rating of images"] = "Pritakso de bildoj";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Elektu la ĝustan pritakson de via avataro por via retejo. Vidu README.";
+$a->strings["Gravatar settings updated."] = "Gravatar agordoj ĝisdatigitaj.";

--- a/gravatar/lang/es/messages.po
+++ b/gravatar/lang/es/messages.po
@@ -1,0 +1,75 @@
+# ADDON gravatar
+# Copyright (C)
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+# 
+# Translators:
+# Albert, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: friendica\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: 2016-11-16 16:51+0000\n"
+"Last-Translator: Albert\n"
+"Language-Team: Spanish (http://www.transifex.com/Friendica/friendica/language/es/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: es\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr "imagen de perfir genético"
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr "patrón geométrico aleatorio"
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr "cara de monstruo"
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr "cara generada por ordenador"
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr "cara estilo arcade clásico"
+
+#: gravatar.php:89
+msgid "Information"
+msgstr "información"
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr "El addon Libravatar está instalado también. Por favor deshabilite el addon de Libravatar o este addon de Gravatar.<br>El addon de Libravatar retrocederá a Gravatar si no se encuentra nada en Libravatar."
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr "Enviar"
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr "Imagen de avatar por defecto"
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr "Seleccionar la imagen de avatar por defecto si no se encuentra ninguna en Gravatar. Vea README"
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr "Clasificación de imágenes"
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr "Seleccionar la apropiada clasificación de avatar para su página. Vea README"
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr "Ajustes de Gravatar actualizados."

--- a/gravatar/lang/es/strings.php
+++ b/gravatar/lang/es/strings.php
@@ -1,0 +1,20 @@
+<?php
+
+if(! function_exists("string_plural_select_es")) {
+function string_plural_select_es($n){
+	return ($n != 1);;
+}}
+;
+$a->strings["generic profile image"] = "imagen de perfir genético";
+$a->strings["random geometric pattern"] = "patrón geométrico aleatorio";
+$a->strings["monster face"] = "cara de monstruo";
+$a->strings["computer generated face"] = "cara generada por ordenador";
+$a->strings["retro arcade style face"] = "cara estilo arcade clásico";
+$a->strings["Information"] = "información";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "El addon Libravatar está instalado también. Por favor deshabilite el addon de Libravatar o este addon de Gravatar.<br>El addon de Libravatar retrocederá a Gravatar si no se encuentra nada en Libravatar.";
+$a->strings["Submit"] = "Enviar";
+$a->strings["Default avatar image"] = "Imagen de avatar por defecto";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Seleccionar la imagen de avatar por defecto si no se encuentra ninguna en Gravatar. Vea README";
+$a->strings["Rating of images"] = "Clasificación de imágenes";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Seleccionar la apropiada clasificación de avatar para su página. Vea README";
+$a->strings["Gravatar settings updated."] = "Ajustes de Gravatar actualizados.";

--- a/gravatar/lang/fr/messages.po
+++ b/gravatar/lang/fr/messages.po
@@ -1,0 +1,75 @@
+# ADDON gravatar
+# Copyright (C)
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+# 
+# Translators:
+# Nicola Spanti <translations@nicola-spanti.info>, 2015
+msgid ""
+msgstr ""
+"Project-Id-Version: friendica\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: 2015-08-30 17:12+0000\n"
+"Last-Translator: Nicola Spanti <translations@nicola-spanti.info>\n"
+"Language-Team: French (http://www.transifex.com/Friendica/friendica/language/fr/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: fr\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr "image de profil générique"
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr ""
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr ""
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr "visage généré par ordinateur"
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr ""
+
+#: gravatar.php:89
+msgid "Information"
+msgstr "Information"
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr ""
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr "Envoyer"
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr "Image par défaut d'avatar"
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr ""
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr ""
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr ""
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr "Paramètres de Gravatar mis à jour."

--- a/gravatar/lang/fr/strings.php
+++ b/gravatar/lang/fr/strings.php
@@ -1,0 +1,20 @@
+<?php
+
+if(! function_exists("string_plural_select_fr")) {
+function string_plural_select_fr($n){
+	return ($n > 1);;
+}}
+;
+$a->strings["generic profile image"] = "image de profil générique";
+$a->strings["random geometric pattern"] = "";
+$a->strings["monster face"] = "";
+$a->strings["computer generated face"] = "visage généré par ordinateur";
+$a->strings["retro arcade style face"] = "";
+$a->strings["Information"] = "Information";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "";
+$a->strings["Submit"] = "Envoyer";
+$a->strings["Default avatar image"] = "Image par défaut d'avatar";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "";
+$a->strings["Rating of images"] = "";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "";
+$a->strings["Gravatar settings updated."] = "Paramètres de Gravatar mis à jour.";

--- a/gravatar/lang/is/strings.php
+++ b/gravatar/lang/is/strings.php
@@ -1,0 +1,15 @@
+<?php
+
+$a->strings["generic profile image"] = "";
+$a->strings["random geometric pattern"] = "";
+$a->strings["monster face"] = "";
+$a->strings["computer generated face"] = "";
+$a->strings["retro arcade style face"] = "";
+$a->strings["Information"] = "";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "";
+$a->strings["Submit"] = "Senda inn";
+$a->strings["Default avatar image"] = "";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "";
+$a->strings["Rating of images"] = "";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "";
+$a->strings["Gravatar settings updated."] = "";

--- a/gravatar/lang/it/messages.po
+++ b/gravatar/lang/it/messages.po
@@ -1,0 +1,75 @@
+# ADDON gravatar
+# Copyright (C)
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+# 
+# Translators:
+# fabrixxm <fabrix.xm@gmail.com>, 2014-2015
+msgid ""
+msgstr ""
+"Project-Id-Version: friendica\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: 2015-08-31 10:12+0000\n"
+"Last-Translator: fabrixxm <fabrix.xm@gmail.com>\n"
+"Language-Team: Italian (http://www.transifex.com/Friendica/friendica/language/it/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: it\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr "immagine generica del profilo"
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr "schema geometrico casuale"
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr "faccia di mostro"
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr "faccia generata dal computer"
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr "faccia stile retro arcade"
+
+#: gravatar.php:89
+msgid "Information"
+msgstr "Informazione"
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr "I'addon Libravatar è installto. Disabilita l'addon Libravatar o questo addon Gravatar<br>L'addon Libravatar si appoggerà a Gravatar se non trova nulla su Libravatar."
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr "Invia"
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr "Immagine avatar predefinita"
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr "Seleziona l'immagine di default se non viene  trovato niente. Vedi README"
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr "Valutazione delle immagini"
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr "Seleziona la valutazione dell'avatar appropriata per il tuo sito. Vedi README"
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr "Impostazioni Gravatar aggiornate."

--- a/gravatar/lang/it/strings.php
+++ b/gravatar/lang/it/strings.php
@@ -1,0 +1,20 @@
+<?php
+
+if(! function_exists("string_plural_select_it")) {
+function string_plural_select_it($n){
+	return ($n != 1);;
+}}
+;
+$a->strings["generic profile image"] = "immagine generica del profilo";
+$a->strings["random geometric pattern"] = "schema geometrico casuale";
+$a->strings["monster face"] = "faccia di mostro";
+$a->strings["computer generated face"] = "faccia generata dal computer";
+$a->strings["retro arcade style face"] = "faccia stile retro arcade";
+$a->strings["Information"] = "Informazione";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "I'addon Libravatar è installto. Disabilita l'addon Libravatar o questo addon Gravatar<br>L'addon Libravatar si appoggerà a Gravatar se non trova nulla su Libravatar.";
+$a->strings["Submit"] = "Invia";
+$a->strings["Default avatar image"] = "Immagine avatar predefinita";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Seleziona l'immagine di default se non viene  trovato niente. Vedi README";
+$a->strings["Rating of images"] = "Valutazione delle immagini";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Seleziona la valutazione dell'avatar appropriata per il tuo sito. Vedi README";
+$a->strings["Gravatar settings updated."] = "Impostazioni Gravatar aggiornate.";

--- a/gravatar/lang/nb-no/strings.php
+++ b/gravatar/lang/nb-no/strings.php
@@ -1,0 +1,15 @@
+<?php
+
+$a->strings["generic profile image"] = "";
+$a->strings["random geometric pattern"] = "";
+$a->strings["monster face"] = "";
+$a->strings["computer generated face"] = "";
+$a->strings["retro arcade style face"] = "";
+$a->strings["Information"] = "";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "";
+$a->strings["Submit"] = "Lagre";
+$a->strings["Default avatar image"] = "";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "";
+$a->strings["Rating of images"] = "";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "";
+$a->strings["Gravatar settings updated."] = "";

--- a/gravatar/lang/pl/strings.php
+++ b/gravatar/lang/pl/strings.php
@@ -1,0 +1,15 @@
+<?php
+
+$a->strings["generic profile image"] = "generuj obraz profilowy";
+$a->strings["random geometric pattern"] = "przypadkowy wzorzec geometryczny";
+$a->strings["monster face"] = "monster face";
+$a->strings["computer generated face"] = "";
+$a->strings["retro arcade style face"] = "";
+$a->strings["Information"] = "";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "";
+$a->strings["Submit"] = "Potwierdź";
+$a->strings["Default avatar image"] = "Domyślny awatar";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "";
+$a->strings["Rating of images"] = "";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "";
+$a->strings["Gravatar settings updated."] = "Zaktualizowane ustawienie Gravatara";

--- a/gravatar/lang/pt-br/messages.po
+++ b/gravatar/lang/pt-br/messages.po
@@ -1,0 +1,75 @@
+# ADDON gravatar
+# Copyright (C)
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+# 
+# Translators:
+# Beatriz Vital <vitalb@riseup.net>, 2016
+msgid ""
+msgstr ""
+"Project-Id-Version: friendica\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: 2016-08-16 11:51+0000\n"
+"Last-Translator: Beatriz Vital <vitalb@riseup.net>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/Friendica/friendica/language/pt_BR/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pt_BR\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr "imagem de perfil genérica"
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr "estampa geométrica aleatória"
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr "careta"
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr "rosto gerado por computador"
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr "rosto de personagem de fliperama"
+
+#: gravatar.php:89
+msgid "Information"
+msgstr "Informação"
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr "O complemento Libravatar também está instalado. Desabilite o  Libravatar ou este complemento, o Gravatar.<br>Se não encontrar nada, o Libravatar remeterá ao Gravatar."
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr "Enviar"
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr "Avatar padrão"
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr "Selecione a imagem de avatar padrão que será usada se nenhuma for encontrada no Gravatar. Veja README."
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr "Classificação de imagens"
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr "Selecione a classificação apropriada para os avatares que serão mostrados no seu site. Veja README."
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr "As configurações do Gravatar foram atualizadas."

--- a/gravatar/lang/pt-br/strings.php
+++ b/gravatar/lang/pt-br/strings.php
@@ -1,0 +1,20 @@
+<?php
+
+if(! function_exists("string_plural_select_pt_br")) {
+function string_plural_select_pt_br($n){
+	return ($n > 1);;
+}}
+;
+$a->strings["generic profile image"] = "imagem de perfil genérica";
+$a->strings["random geometric pattern"] = "estampa geométrica aleatória";
+$a->strings["monster face"] = "careta";
+$a->strings["computer generated face"] = "rosto gerado por computador";
+$a->strings["retro arcade style face"] = "rosto de personagem de fliperama";
+$a->strings["Information"] = "Informação";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "O complemento Libravatar também está instalado. Desabilite o  Libravatar ou este complemento, o Gravatar.<br>Se não encontrar nada, o Libravatar remeterá ao Gravatar.";
+$a->strings["Submit"] = "Enviar";
+$a->strings["Default avatar image"] = "Avatar padrão";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Selecione a imagem de avatar padrão que será usada se nenhuma for encontrada no Gravatar. Veja README.";
+$a->strings["Rating of images"] = "Classificação de imagens";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Selecione a classificação apropriada para os avatares que serão mostrados no seu site. Veja README.";
+$a->strings["Gravatar settings updated."] = "As configurações do Gravatar foram atualizadas.";

--- a/gravatar/lang/ro/messages.po
+++ b/gravatar/lang/ro/messages.po
@@ -1,0 +1,75 @@
+# ADDON gravatar
+# Copyright (C)
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+# 
+# Translators:
+# Doru  DEACONU <dumitrudeaconu@yahoo.com>, 2014
+msgid ""
+msgstr ""
+"Project-Id-Version: friendica\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: 2014-11-27 14:18+0000\n"
+"Last-Translator: Doru  DEACONU <dumitrudeaconu@yahoo.com>\n"
+"Language-Team: Romanian (Romania) (http://www.transifex.com/projects/p/friendica/language/ro_RO/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ro_RO\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?2:1));\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr "imagine generică de profil"
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr "șablon geometric aleator"
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr "chip monstruos"
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr "chip generat de calculator"
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr "chip în stil jocuri arcade retro "
+
+#: gravatar.php:89
+msgid "Information"
+msgstr "Informaţii"
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr "Modulul Libravatar este instalat, de asemenea. Vă rugăm să dezactivați modulul Libravatar sau acest modul Gravatar. <br>Modulul Libravatar va reveni înapoi la Gravatar, dacă nu s-a găsit nimic în Libravatar."
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr "Trimite"
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr "Imagine avatar implicită"
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr "Selectați imagine avatar implicită, dacă nici una nu fost găsită în Gravatar. Consultați FIŞIERUL README"
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr "Evaluările imaginilor"
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr "Selectați evaluarea adecvată a avatarului pentru site-ul dumneavoastră. Consultați FIŞIERUL README"
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr "Configurările Gravatar au fost actualizate."

--- a/gravatar/lang/ro/strings.php
+++ b/gravatar/lang/ro/strings.php
@@ -1,0 +1,20 @@
+<?php
+
+if(! function_exists("string_plural_select_ro")) {
+function string_plural_select_ro($n){
+	return ($n==1?0:((($n%100>19)||(($n%100==0)&&($n!=0)))?2:1));;
+}}
+;
+$a->strings["generic profile image"] = "imagine generică de profil";
+$a->strings["random geometric pattern"] = "șablon geometric aleator";
+$a->strings["monster face"] = "chip monstruos";
+$a->strings["computer generated face"] = "chip generat de calculator";
+$a->strings["retro arcade style face"] = "chip în stil jocuri arcade retro ";
+$a->strings["Information"] = "Informaţii";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "Modulul Libravatar este instalat, de asemenea. Vă rugăm să dezactivați modulul Libravatar sau acest modul Gravatar. <br>Modulul Libravatar va reveni înapoi la Gravatar, dacă nu s-a găsit nimic în Libravatar.";
+$a->strings["Submit"] = "Trimite";
+$a->strings["Default avatar image"] = "Imagine avatar implicită";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Selectați imagine avatar implicită, dacă nici una nu fost găsită în Gravatar. Consultați FIŞIERUL README";
+$a->strings["Rating of images"] = "Evaluările imaginilor";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Selectați evaluarea adecvată a avatarului pentru site-ul dumneavoastră. Consultați FIŞIERUL README";
+$a->strings["Gravatar settings updated."] = "Configurările Gravatar au fost actualizate.";

--- a/gravatar/lang/ru/messages.po
+++ b/gravatar/lang/ru/messages.po
@@ -1,0 +1,75 @@
+# ADDON gravatar
+# Copyright (C)
+# This file is distributed under the same license as the Friendica gravatar addon package.
+# 
+# 
+# Translators:
+# Stanislav N. <pztrn@pztrn.name>, 2017
+msgid ""
+msgstr ""
+"Project-Id-Version: friendica\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2013-02-27 05:01-0500\n"
+"PO-Revision-Date: 2017-04-08 17:23+0000\n"
+"Last-Translator: Stanislav N. <pztrn@pztrn.name>\n"
+"Language-Team: Russian (http://www.transifex.com/Friendica/friendica/language/ru/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ru\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: gravatar.php:71
+msgid "generic profile image"
+msgstr "общее изображение профиля"
+
+#: gravatar.php:72
+msgid "random geometric pattern"
+msgstr "случайный геометрический паттерн"
+
+#: gravatar.php:73
+msgid "monster face"
+msgstr "monster face"
+
+#: gravatar.php:74
+msgid "computer generated face"
+msgstr "сгенерированное лицо"
+
+#: gravatar.php:75
+msgid "retro arcade style face"
+msgstr "лицо в стиле retro arcade"
+
+#: gravatar.php:89
+msgid "Information"
+msgstr "Информация"
+
+#: gravatar.php:89
+msgid ""
+"Libravatar addon is installed, too. Please disable Libravatar addon or this "
+"Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if "
+"nothing was found at Libravatar."
+msgstr "Аддон Libravatar тоже установлен. Пожалуйста, отключите его.<br>Libravatar использует Gravatar если Libravatar не может найти изображение у себя."
+
+#: gravatar.php:95
+msgid "Submit"
+msgstr "Добавить"
+
+#: gravatar.php:96
+msgid "Default avatar image"
+msgstr "Аватар по умолчанию"
+
+#: gravatar.php:96
+msgid "Select default avatar image if none was found at Gravatar. See README"
+msgstr "Выберите аватар по умолчанию если ничего не было найдено на Gravatar. Смотрите README"
+
+#: gravatar.php:97
+msgid "Rating of images"
+msgstr "Рейтинг изображений"
+
+#: gravatar.php:97
+msgid "Select the appropriate avatar rating for your site. See README"
+msgstr "Выберите нужный рейтинг изображений для вашего сайта. Смотрите README"
+
+#: gravatar.php:111
+msgid "Gravatar settings updated."
+msgstr "Настройки Gravatar обновлены."

--- a/gravatar/lang/ru/strings.php
+++ b/gravatar/lang/ru/strings.php
@@ -1,0 +1,20 @@
+<?php
+
+if(! function_exists("string_plural_select_ru")) {
+function string_plural_select_ru($n){
+	return ($n%10==1 && $n%100!=11 ? 0 : $n%10>=2 && $n%10<=4 && ($n%100<12 || $n%100>14) ? 1 : $n%10==0 || ($n%10>=5 && $n%10<=9) || ($n%100>=11 && $n%100<=14)? 2 : 3);;
+}}
+;
+$a->strings["generic profile image"] = "общее изображение профиля";
+$a->strings["random geometric pattern"] = "случайный геометрический паттерн";
+$a->strings["monster face"] = "monster face";
+$a->strings["computer generated face"] = "сгенерированное лицо";
+$a->strings["retro arcade style face"] = "лицо в стиле retro arcade";
+$a->strings["Information"] = "Информация";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "Аддон Libravatar тоже установлен. Пожалуйста, отключите его.<br>Libravatar использует Gravatar если Libravatar не может найти изображение у себя.";
+$a->strings["Submit"] = "Добавить";
+$a->strings["Default avatar image"] = "Аватар по умолчанию";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "Выберите аватар по умолчанию если ничего не было найдено на Gravatar. Смотрите README";
+$a->strings["Rating of images"] = "Рейтинг изображений";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "Выберите нужный рейтинг изображений для вашего сайта. Смотрите README";
+$a->strings["Gravatar settings updated."] = "Настройки Gravatar обновлены.";

--- a/gravatar/lang/sv/strings.php
+++ b/gravatar/lang/sv/strings.php
@@ -1,0 +1,3 @@
+<?php
+
+$a->strings["Submit"] = "Spara";

--- a/gravatar/lang/zh-cn/strings.php
+++ b/gravatar/lang/zh-cn/strings.php
@@ -1,0 +1,15 @@
+<?php
+
+$a->strings["generic profile image"] = "通用简介图片";
+$a->strings["random geometric pattern"] = "随机的几何图案";
+$a->strings["monster face"] = "怪物面子";
+$a->strings["computer generated face"] = "电脑造成的面子";
+$a->strings["retro arcade style face"] = "复古游乐场式面子";
+$a->strings["Information"] = "信息";
+$a->strings["Libravatar addon is installed, too. Please disable Libravatar addon or this Gravatar addon.<br>The Libravatar addon will fall back to Gravatar if nothing was found at Libravatar."] = "Libravatar加件页安装着。请是Libravatar加件或者这个Gravatar加件。<br>Libravatar加件没找到在Libravatar的时候可依靠的是Gravatar";
+$a->strings["Submit"] = "提交";
+$a->strings["Default avatar image"] = "默认纸娃娃系统";
+$a->strings["Select default avatar image if none was found at Gravatar. See README"] = "如果Gravatar上没找到纸娃娃系统选择默认的。看README";
+$a->strings["Rating of images"] = "照相评定";
+$a->strings["Select the appropriate avatar rating for your site. See README"] = "选择适合您网站的纸娃娃系统。看README";
+$a->strings["Gravatar settings updated."] = "Gravatar设置更新了。";

--- a/gravatar/view/tpl/admin.tpl
+++ b/gravatar/view/tpl/admin.tpl
@@ -1,0 +1,3 @@
+{{include file="field_select.tpl" field=$default_avatar}}
+{{include file="field_select.tpl" field=$rating}}
+<div class="submit"><input type="submit" value="{{$submit}}" /></div>

--- a/noembed/noembed.php
+++ b/noembed/noembed.php
@@ -6,7 +6,8 @@
  * Version: 1.0
  * Author: Jeroen van Riet Paap <jeroenpraat@hubzilla.nl>, Mike Macgirvin <mike@zothub.com>
  * Maintainer: Jeroen van Riet Paap <jeroenpraat@hubzilla.nl>
- * 
+ * Committer
+ *
  */
 
 function noembed_load() {
@@ -19,7 +20,7 @@ function noembed_unload() {
 
 function noembed_oembed_probe(&$a,&$b) {
 	// try noembed service
-	$ourl = 'https://noembed.com/embed?url=' . urlencode($b['url']);  
+	$ourl = 'https://noembed.com/embed?url=' . urlencode($b['url']);
 	$result = z_fetch_url($ourl);
 	if($result['success'])
 		$b['embed'] = $result['body'];

--- a/noembed/noembed.php
+++ b/noembed/noembed.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Name: Noembed
  * Description: Use noembed.com as an addition to Hubzilla's native oembed functionality
@@ -7,12 +8,15 @@
  * Maintainer: Jeroen van Riet Paap <jeroenpraat@hubzilla.nl>
  * 
  */
+
 function noembed_load() {
 	register_hook('oembed_probe','addon/noembed/noembed.php','noembed_oembed_probe');
 }
+
 function noembed_unload() {
 	unregister_hook('oembed_probe','addon/noembed/noembed.php','noembed_oembed_probe');
 }
+
 function noembed_oembed_probe(&$a,&$b) {
 	// try noembed service
 	$ourl = 'https://noembed.com/embed?url=' . urlencode($b['url']);  

--- a/noembed/noembed.php
+++ b/noembed/noembed.php
@@ -6,8 +6,7 @@
  * Version: 1.0
  * Author: Jeroen van Riet Paap <jeroenpraat@hubzilla.nl>, Mike Macgirvin <mike@zothub.com>
  * Maintainer: Jeroen van Riet Paap <jeroenpraat@hubzilla.nl>
- * Committer
- *
+ * 
  */
 
 function noembed_load() {
@@ -20,7 +19,7 @@ function noembed_unload() {
 
 function noembed_oembed_probe(&$a,&$b) {
 	// try noembed service
-	$ourl = 'https://noembed.com/embed?url=' . urlencode($b['url']);
+	$ourl = 'https://noembed.com/embed?url=' . urlencode($b['url']);  
 	$result = z_fetch_url($ourl);
 	if($result['success'])
 		$b['embed'] = $result['body'];

--- a/pubsubhubbub/pubsubhubbub.php
+++ b/pubsubhubbub/pubsubhubbub.php
@@ -131,7 +131,7 @@ function push_notifier_process(&$a,&$b) {
 		return;
 	}
 
-	$feed = get_feed_for($channel,'', 'compat' => 1, 'start' => 0, 'records' => 10 ));
+	$feed = get_feed_for($channel,'', [ 'compat' => 1, 'start' => 0, 'records' => 10 ]);
 
 	foreach($r as $rr) {
 


### PR DESCRIPTION
### Porting of gravatar plugin  by Klaus Weidenbach <http://friendica.dszdw.net/profile/klaus>  from https://github.com/friendica/friendica-addons

This addon allows you to look up an avatar image for new users and contacts at [Gravatar](http://www.gravatar.com).

The plugin has administrator settings allowing  to set the default rating and avatar. Default avatar is returned if saved avatar is not found on http://www.gravatar.com. Search for an avatar is based on the hash value which is generated on a hub account email value. If avatar for hash value is not found then default avatar is returned.

Option for selection of hub default profile photo as default  http://www.gravatar.com avatar is added for this plugin port.

