### PR TITLE
pubcrawl: Add mentioned users to 'cc' for public posts

### DIFF
--- a/pubcrawl/as.php
+++ b/pubcrawl/as.php
@@ -416,13 +416,12 @@ function asencode_activity($i) {
 		$ret['bto'] = as_map_acl($i);
 	}
 
-
 	if(in_array($ret['object']['type'], [ 'Note', 'Article' ])) {
-		if ($ret['to'])
+		if($ret['to'])
 			$ret['object']['to'] = $ret['to'];
-		if ($ret['bto'])
+		if($ret['bto'])
 			$ret['object']['bto'] = $ret['bto'];
-		if ($ret['cc'])
+		if($ret['cc'])
 			$ret['object']['cc'] = $ret['cc'];
 	}
 

--- a/pubcrawl/as.php
+++ b/pubcrawl/as.php
@@ -226,7 +226,6 @@ function asencode_item($i) {
 		$ret['attachment'] = array_merge($img,$ret['attachment']);
 	}
 
-
 	return $ret;
 }
 


### PR DESCRIPTION
Mastodon users didn't get notifications for @-mentions.

To get notifications, mentioned users need to be explicitly listed to be part of the audience inside the activitypub payload.

This change adds mentioned users to 'cc' for public posts.