### PR TITLE
Remove parameter from cart_install()

### DIFF
--- a/cart/cart.php
+++ b/cart/cart.php
@@ -946,7 +946,7 @@ function cart_setcartconfig($param,$val) {
 	return set_pconfig(local_channel(),"cart",$param);
 }
 
-function cart_install(&$a) {
+function cart_install() {
 		logger ('[cart] Install start.',LOGGER_DEBUG);
 	if (cart_dbUpgrade () == UPDATE_FAILED) {
 		notice ('[cart] Install error - Abort installation.');


### PR DESCRIPTION
This should fix the crash on 7.2.  Not sure why it doesn't fail on 5.6.  The parameter was unused, but I think sometime between 2.8 and 3.x it got removed from the include/plugin.php  $func() call for the install function.